### PR TITLE
fix size argument for logrotate: m -> M

### DIFF
--- a/roles/apps/templates/app.logrotate.j2
+++ b/roles/apps/templates/app.logrotate.j2
@@ -1,7 +1,7 @@
 /var/app/shared/log/{{ myapp_env }}.log {
     missingok
     notifempty
-    size 20m
+    size 20M
     daily
     create 0644 webapp webapp
 }
@@ -9,7 +9,7 @@
 /var/app/support/logs/error.log {
     missingok
     notifempty
-    size 20m
+    size 20M
     daily
     create 0644 root root
 }
@@ -17,7 +17,7 @@
 /var/app/support/logs/host.access.log {
     missingok
     notifempty
-    size 20m
+    size 20M
     daily
     create 0644 root root
 }

--- a/roles/workers/files/sidekiq.logrotate
+++ b/roles/workers/files/sidekiq.logrotate
@@ -1,7 +1,7 @@
 /var/app/support/logs/error.log {
     missingok
     notifempty
-    size 20m
+    size 20M
     daily
     create 0644 webapp webapp
 }


### PR DESCRIPTION
Hi, we noticed our logs were not getting rotated as expected, and traced it back to this error in our cron mail:

error: /etc/logrotate.d/appnginx:4 unknown unit 'm'

The man page for logrotate gives k, M, and G as valid size suffixes, so I believe this is just a typo.  If I'm getting this wrong let me know, but I believe this will fix the problem.
